### PR TITLE
update workshop to support djl-serving

### DIFF
--- a/02-sm-inference.ipynb
+++ b/02-sm-inference.ipynb
@@ -77,12 +77,14 @@
    "source": [
     "import sagemaker\n",
     "import boto3\n",
-    "from sagemaker.pytorch.model import PyTorchModel\n",
     "from sagemaker.local import LocalSession\n",
     "from sagemaker.model import Model\n",
+    "from sagemaker.predictor import Predictor\n",
     "from sagemaker import get_execution_role\n",
     "from sagemaker.serializers import JSONSerializer\n",
     "from sagemaker.deserializers import JSONDeserializer\n",
+    "from sagemaker.s3 import S3Uploader\n",
+    "from datetime import datetime\n",
     "import numpy as np\n",
     "import json"
    ]
@@ -99,8 +101,10 @@
     "# session = LocalSession()\n",
     "# session.config = {'local': {'local_code': True } }\n",
     "session = sagemaker.Session()\n",
+    "bucket = session.default_bucket()\n",
     "role = get_execution_role()\n",
-    "model_data_url = sm_model_s3_url"
+    "model_data_url = sm_model_s3_url\n",
+    "region = session.boto_region_name"
    ]
   },
   {
@@ -130,6 +134,112 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "789581af-ce15-4076-996d-bfec490bb944",
+   "metadata": {},
+   "source": [
+    "## AWS Deep Learning Containers\n",
+    "[AWS Deep Learning Containers](https://github.com/aws/deep-learning-containers) (DLCs) are a set of Docker images for training and serving models in TensorFlow, TensorFlow 2, PyTorch and others. Deep Learning Containers provide optimized environments with TensorFlow, Nvidia CUDA (for GPU instances), and Intel MKL (for CPU instances) libraries and are available in the Amazon Elastic Container Registry (Amazon ECR).\n",
+    "\n",
+    "To retrieve a specific container image, you can directly reference the ECR URI in the github link, or use SageMaker SDK to return the proper URI based on the frameowork version. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db107541-b8b8-40f7-9cef-020074c4bfb4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find inference container image\n",
+    "inference_image_uri = sagemaker.image_uris.retrieve(\n",
+    "    framework='djl-lmi', # use lmi image until deep learning image is available\n",
+    "    region=region,\n",
+    "    py_version='py311',\n",
+    "    image_scope=\"inference\",\n",
+    "    instance_type='ml.p3.2xlarge'\n",
+    ")\n",
+    "# temporary until sdk updates djl container images fpr py311\n",
+    "inference_image_uri = f'763104351884.dkr.ecr.{region}.amazonaws.com/djl-inference:0.32.0-lmi14.0.0-cu126'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d251dc4-5fb8-4c9d-9d1a-a9dcb120e5ca",
+   "metadata": {},
+   "source": [
+    "## DJL Serving\n",
+    "\n",
+    "DJL Serving is a high performance universal stand-alone model serving solution. It takes a deep learning model, several models, or workflows and makes them available through an HTTP endpoint.\n",
+    "\n",
+    "DJL Serving accepts the following artifacts in your archive:\n",
+    "\n",
+    "- Model checkpoint: Files that store your model weights.\n",
+    "\n",
+    "- serving.properties: A configuration file that you can add for each model. Place serving.properties in the same directory as your model file.\n",
+    "\n",
+    "- model.py: The inference handler code. This is only applicable when using Python mode. If you don't specify model.py, djl-serving uses one of the default handlers.\n",
+    "\n",
+    "The following is an example of a model.tar.gz structure:\n",
+    "\n",
+    "\n",
+    "```\n",
+    "- model_root_dir # root directory\n",
+    "  - serving.properties # A configuration file that you can add for each model. Place serving.properties in the same directory as your model file.      \n",
+    "  - model.py # your custom handler file for Python, if you choose not to use the default handlers provided by DJL Serving\n",
+    "  - model binary files # used for Java mode, or if you don't want to use option.model_id and option.s3_url for Python mode\n",
+    "```\n",
+    "\n",
+    "For more information about DJL Serving, please refer to this [link](https://docs.djl.ai/master/docs/serving/index.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbc29a92-9e64-46ab-8286-89ee6d6f7af1",
+   "metadata": {},
+   "source": [
+    "Download model binary files and add inference code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97e32bf0-8954-4b96-b989-6b5aaed024c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!aws s3 cp {model_data_url} model/model.tar.gz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9058e6ae-26a4-4dc3-b6be-76fe2c65601a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sh\n",
+    "rm -rf temp/ && mkdir -p temp && cd temp\n",
+    "tar -xvzf ../model/model.tar.gz >/dev/null 2>&1\n",
+    "cp -R ../src/* ./ && rm -rd data && rm train.py\n",
+    "tar -cvzf ../model/model.tar.gz . >/dev/null 2>&1 && cd .. && rm -rf temp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e938a841-11bf-4fed-ac89-8fed258874eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_name = f\"two-tower-{datetime.now():%Y-%m-%d-%H-%M-%S}\"\n",
+    "model_url = S3Uploader.upload(\n",
+    "    local_path=\"model/model.tar.gz\",\n",
+    "    desired_s3_uri=f\"s3://{bucket}/models/{model_name}\",\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "06a260b2-eef7-42c3-9742-51f032c2e69c",
@@ -138,15 +248,14 @@
    },
    "outputs": [],
    "source": [
-    "# Create PyTorch model\n",
-    "pytorch_model = PyTorchModel(\n",
+    "# Create model\n",
+    "model = Model(\n",
+    "    image_uri=inference_image_uri,\n",
     "    source_dir=\"src\",\n",
-    "    model_data=model_data_url,\n",
+    "    model_data=model_url,\n",
     "    role=role,\n",
-    "    entry_point=\"inference.py\",\n",
-    "    framework_version=\"2.5.1\",\n",
-    "    py_version=\"py311\",\n",
     "    sagemaker_session=session,\n",
+    "    predictor_cls=Predictor,\n",
     "    env={\n",
     "        \"MASTER_ADDR\" : \"localhost\", \n",
     "        \"MASTER_PORT\" : \"12356\", \n",
@@ -173,7 +282,7 @@
    },
    "outputs": [],
    "source": [
-    "predictor = pytorch_model.deploy(\n",
+    "predictor = model.deploy(\n",
     "    initial_instance_count=1,\n",
     "    # instance_type='local_gpu', # uncomment if running in a local mode.\n",
     "    instance_type='ml.p3.2xlarge',\n",
@@ -185,24 +294,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d251dc4-5fb8-4c9d-9d1a-a9dcb120e5ca",
+   "id": "2aa8af74-84d0-4d52-8bfe-ad5aad0487e9",
    "metadata": {},
    "source": [
-    "## SageMaker Inference Toolkit for Model Lifecycle Handling\n",
-    "The [inference.py](src/inference.py) script uses SageMaker Inference toolkit standard structure for the lifecycle of the model. The script implements the following key functions that the model server used to orchestrate incoming inference requests and loading/unloading of the model:\n",
-    "\n",
-    "* def model_fn(model_dir) - Function that handles model loading steps.\n",
-    "\n",
-    "* def input_fn(input_data, content_type) - Function that transforms the input data.\n",
-    "\n",
-    "* def predict_fn(self, data, model) - Function that perform inference on the given data.\n",
-    "\n",
-    "* def output_fn(prediction, accept) - Function that transforms the response data before returning the payload to the caller.\n",
-    "\n",
-    "\n",
-    "For more information about SageMaker Inference Toolkit, please refer to this [link](https://github.com/aws/sagemaker-inference-toolkit).\n",
-    "\n",
-    "Following is the code for [inference.py](src/inference.py)"
+    "The following is the code for [model.py](src/model.py)"
    ]
   },
   {
@@ -212,7 +307,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load src/inference.py"
+    "%load src/model.py"
    ]
   },
   {

--- a/03-sm-shadow-test.ipynb
+++ b/03-sm-shadow-test.ipynb
@@ -79,7 +79,6 @@
    "source": [
     "import sagemaker\n",
     "import boto3\n",
-    "from sagemaker.pytorch.model import PyTorchModel\n",
     "from sagemaker.local import LocalSession\n",
     "from sagemaker.model import Model\n",
     "from sagemaker import get_execution_role\n",
@@ -136,6 +135,7 @@
     "model_data_url = model_serving_data_s3_uri\n",
     "bucket = session.default_bucket()\n",
     "prefix = \"models/shadow-test\"\n",
+    "region = session.boto_region_name\n",
     "\n",
     "sm = boto3.client(\"sagemaker\")\n",
     "sm_runtime = boto3.client(\"sagemaker-runtime\")"
@@ -176,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!rm -rf temp/ && mkdir -p temp && cd temp && tar -xvzf ../model/shadow.tar.gz >/dev/null 2>&1 && cp ../shadow/inference.py code/inference.py && tar -cvzf ../model/shadow.tar.gz . >/dev/null 2>&1 && cd .. && rm -rf temp"
+    "!rm -rf temp/ && mkdir -p temp && cd temp && tar -xvzf ../model/shadow.tar.gz >/dev/null 2>&1 && cp ../shadow/model.py model.py && tar -cvzf ../model/shadow.tar.gz . >/dev/null 2>&1 && cd .. && rm -rf temp"
    ]
   },
   {
@@ -238,14 +238,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Find inference container image\n",
     "inference_image_uri = sagemaker.image_uris.retrieve(\n",
-    "    framework='pytorch',\n",
-    "    region=boto3.Session().region_name, \n",
-    "    version='2.5.1',     # PyTorch version\n",
-    "    py_version='py311',  # Python version\n",
-    "    image_scope='inference',\n",
-    "    instance_type='ml.g4dn.2xlarge' \n",
-    ")"
+    "    framework=\"djl-lmi\", # use lmi image until deep learning image is available\n",
+    "    region=region,\n",
+    "    py_version=\"py311\",\n",
+    "    image_scope=\"inference\",\n",
+    "    instance_type=\"ml.g4dn.2xlarge\"\n",
+    ")\n",
+    "# temporary until sdk updates djl container images fpr py311\n",
+    "inference_image_uri = f'763104351884.dkr.ecr.{region}.amazonaws.com/djl-inference:0.32.0-lmi14.0.0-cu126'"
    ]
   },
   {

--- a/src/model.py
+++ b/src/model.py
@@ -1,3 +1,5 @@
+from djl_python import Input, Output
+
 from typing import List, Optional
 import json
 import os
@@ -27,25 +29,34 @@ from modules.two_tower import (  # noqa F811
     TwoTowerRetrieval,
 )
 
+
 two_tower_column_names = DEFAULT_RATINGS_COLUMN_NAMES[:2]
 local_rank = int(os.environ.get("LOCAL_RANK", "0"))
 world_size = int(os.environ.get("WORLD_SIZE", "1"))
 rank = int(os.environ.get("RANK", "0"))
 
-def load_model(num_embeddings: int = 1024 * 1024,
-            embedding_dim: int = 64,
-            layer_sizes: Optional[List[int]] = None,
-            num_centroids: int = 100,
-            k: int = 100,
-            num_subquantizers: int = 8,
-            bits_per_code: int = 8,
-            num_probe: int = 8,
-            model_device_idx: int = 0,
-            faiss_device_idx: int = 0,
-            batch_size: int = 32,
-            load_dir: Optional[str] = "/opt/ml/model",
-            world_size: int = 1,
-        ) -> DistributedModelParallel:
+
+class TwoTowerHandler(object):
+    def __init__(self):
+        self.model = None
+        self.device = None
+        self.initialized = False
+
+    def load_model(self,
+                   num_embeddings: int = 1024 * 1024,
+                   embedding_dim: int = 64,
+                   layer_sizes: Optional[List[int]] = None,
+                   num_centroids: int = 100,
+                   k: int = 100,
+                   num_subquantizers: int = 8,
+                   bits_per_code: int = 8,
+                   num_probe: int = 8,
+                   model_device_idx: int = 0,
+                   faiss_device_idx: int = 0,
+                   batch_size: int = 32,
+                   load_dir: Optional[str] = "/opt/ml/model",
+                   world_size: int = 1,
+                   ) -> DistributedModelParallel:
         """
         Loads the serialized model and FAISS index from `two_tower_train.py`.
         A `TwoTowerRetrieval` model is instantiated, which wraps the `KNNIndex`, the query (user) tower and the candidate item (movie) tower inside an `nn.Module`.
@@ -72,8 +83,8 @@ def load_model(num_embeddings: int = 1024 * 1024,
             layer_sizes = [128, 64]
         assert torch.cuda.is_available(), "This example requires a GPU"
 
-        device: torch.device = torch.device(f"cuda:{rank}")
-        torch.cuda.set_device(device)
+        self.device: torch.device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(self.device)
 
         two_tower_column_names = DEFAULT_RATINGS_COLUMN_NAMES[:2]
         ebcs = []
@@ -128,7 +139,7 @@ def load_model(num_embeddings: int = 1024 * 1024,
             index.add(embeddings)
 
         retrieval_model = TwoTowerRetrieval(
-            index, ebcs[0], ebcs[1], layer_sizes, k, device)
+            index, ebcs[0], ebcs[1], layer_sizes, k, self.device)
 
         constraints = {}
         for feature_name in two_tower_column_names:
@@ -137,50 +148,62 @@ def load_model(num_embeddings: int = 1024 * 1024,
                 compute_kernels=[EmbeddingComputeKernel.QUANT.value],
             )
 
-        dmp = DistributedModelParallel(
+        self.model = DistributedModelParallel(
             module=retrieval_model,
-            device=device,
+            device=self.device,
             # env=ShardingEnv.from_local(world_size=world_size, rank=model_device_idx),
             init_data_parallel=False,
         )
 
         if retrieval_sd is not None:
-            dmp.load_state_dict(retrieval_sd)
+            self.model.load_state_dict(retrieval_sd)
 
-        return dmp
+    def initialize(self, properties):
+        """Initialize model and load weights"""
+        self.load_model()
+        # self.model.to(self.device)
+        self.model.eval()
+        self.initialized = True
 
-def model_fn(model_dir):
-    """Load the model for inference"""
-    model = load_model()
-    model.eval()
-    return model
+    def inference(self, inputs: Input) -> Output:
+        if not self.initialized:
+            self.initialize(inputs.get_properties())
 
-def input_fn(request_body, request_content_type):
-    """Deserialize and prepare the prediction input"""
-    if request_content_type == "application/json":
-        input_data = json.loads(request_body)["inputs"]
-        return torch.tensor(input_data, dtype=torch.int64)
-    raise ValueError(f"Unsupported content type: {request_content_type}")
+        # Parse input
+        input_data = inputs.get_as_json().get("inputs")
+        input = torch.tensor(input_data, dtype=torch.int64)
 
-def predict_fn(input_data, model):
-    """Perform prediction"""
+        # Inference
+        batch_size = input.shape[0]
+        batch = KeyedJaggedTensor(
+            keys=[two_tower_column_names[0]],
+            values=input.to(self.device),
+            lengths=torch.tensor([1] * batch_size, device=self.device),
+        )
+        actual_result = self.model(batch)
+        # Convert to NumPy array
+        numpy_data = actual_result.detach().cpu().numpy()
 
-    device = torch.device(f"cuda:{rank}")
-    batch_size = input_data.shape[0]
-    batch = KeyedJaggedTensor(
-        keys=[two_tower_column_names[0]],
-        values=input_data.to(device),
-        lengths=torch.tensor([1] * batch_size, device=device),
-    )
+        # Prepare output
+        result = numpy_data.tolist()
 
-    actual_result = model(batch)
-    # Convert to NumPy array
-    numpy_data = actual_result.detach().cpu().numpy()
-    return numpy_data
+        return Output().add_as_json(result)
 
-def output_fn(prediction, response_content_type):
-    """Serialize and return the prediction output"""
-    if response_content_type == "application/json":
-        response = prediction.tolist()
-        return json.dumps({"predictions": response})
-    raise ValueError(f"Unsupported content type: {response_content_type}")
+
+_service = TwoTowerHandler()
+
+
+def handle(inputs: Input):
+    """
+    Default handler function
+    """
+    if not _service.initialized:
+        # stateful model
+        _service.initialize(inputs.get_properties())
+
+    if inputs.is_empty():
+        # initialization request
+        return None
+
+    return _service.inference(inputs)
+    

--- a/src/serving.properties
+++ b/src/serving.properties
@@ -1,0 +1,3 @@
+engine=Python
+option.entryPoint=model.py
+option.pythonExecutionerName=python3

--- a/src/train.py
+++ b/src/train.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import shutil
 import glob
 from typing import List, Optional
 
@@ -225,6 +226,7 @@ def train(
             torch.save(model.state_dict(), f"{save_dir}/model.pt")
             # pyre-ignore[16]
             faiss.write_index(index, f"{save_dir}/faiss.index")
+
 
 if __name__ =='__main__':
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This update modifies the inference container to use [DJL Serving](https://github.com/deepjavalibrary/djl-serving) instead of the default pytorch container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
